### PR TITLE
fix：添加几个环境配置

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -69,3 +69,9 @@ APP_ENV=development
 
 # NEXT_PUBLIC_UMAMI_DATA_ID=xxx
 # NEXT_PUBLIC_GA_ID=xxx
+
+# openai配置
+OPEN_AI_API_ENDPOINT=xxx
+OPEN_AI_API_KEY=xxx
+OPEN_AI_MODEL=xxx
+FLUX_AI_PROMPT=xxx


### PR DESCRIPTION
根据运行提示，在`.env.example`中添加必要的变量：

```text
# openai配置
OPEN_AI_API_ENDPOINT='http://xxx'
OPEN_AI_API_KEY='xxx'
OPEN_AI_MODEL='xxx'
FLUX_AI_PROMPT='xxx'
```
![image](https://github.com/user-attachments/assets/79d6dd0e-c575-4444-8e8d-1767aa4996de)
